### PR TITLE
fix for turbolinks

### DIFF
--- a/vendor/assets/javascripts/active_admin_scoped_collection_actions.js.coffee
+++ b/vendor/assets/javascripts/active_admin_scoped_collection_actions.js.coffee
@@ -2,7 +2,7 @@
 
 $(document).ready ->
 
-  $('.scoped_collection_action_button').click (e) ->
+  $(document).on 'click', '.scoped_collection_action_button', (e) ->
     e.preventDefault()
     fields = JSON.parse( $(this).attr('data') )
 


### PR DESCRIPTION
Fix for turbolinks. 
Without this fix filter button doesn't trigger anything, because with turbolinks document.ready is called only once on very first page, when there might be no '.scoped_collection_action_button' on page. And when user visits other page with '.scoped_collection_action_button' the button doesn't have click event defined.
