### PR TITLE
fixed batch_action_collection not working with decorators

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ group :test do
   gem 'sprockets-rails', '2.3.3'
   gem 'rails', '~> 5.1'
   gem 'rspec-rails'
+  gem 'draper'
   gem 'activeadmin', '1.0.0'
   gem 'sass-rails'
   gem 'sqlite3'

--- a/lib/active_admin_scoped_collection_actions/controller.rb
+++ b/lib/active_admin_scoped_collection_actions/controller.rb
@@ -1,8 +1,16 @@
 module ActiveAdminScopedCollectionActions
   module Controller
+    COLLECTION_APPLIES = [
+      :authorization_scope,
+      :filtering,
+      :scoping,
+      :includes,
+    ].freeze
+
     def scoped_collection_records
       selection = params.fetch(:collection_selection, [])
-      selection.any? ? batch_action_collection.where(resource_class.primary_key => selection) : batch_action_collection
+      selection.any? ? batch_action_collection(COLLECTION_APPLIES).where(resource_class.primary_key => selection)
+        : batch_action_collection
     end
   end
 end

--- a/lib/active_admin_scoped_collection_actions/controller.rb
+++ b/lib/active_admin_scoped_collection_actions/controller.rb
@@ -10,7 +10,7 @@ module ActiveAdminScopedCollectionActions
     def scoped_collection_records
       selection = params.fetch(:collection_selection, [])
       selection.any? ? batch_action_collection(COLLECTION_APPLIES).where(resource_class.primary_key => selection)
-        : batch_action_collection
+        : batch_action_collection(COLLECTION_APPLIES)
     end
   end
 end

--- a/spec/authors_actions_spec.rb
+++ b/spec/authors_actions_spec.rb
@@ -78,6 +78,25 @@ describe 'authors index', type: :feature, js: true do
   end
 
 
-  context
+  context 'perform Delete-action when cheked only one item' do
+
+    let(:delete_author) { Author.first }
+
+    before do
+      page.find('#collection_actions_sidebar_section button', text: 'Delete').click
+      page.find("#batch_action_item_#{delete_author.id}").trigger('click')
+      page.within ('body>.active_admin_dialog_mass_update_by_filter') do
+        page.find('button', text: 'OK').click
+      end
+    end
+
+    it 'delete only cheked author' do
+      expect(page).to have_css('.flashes .flash.flash_notice')
+      expect(Author.count).to eq(1)
+      expect(Author.take.id).not_to eq(delete_author.id)
+      expect(page).to have_css("#batch_action_item_#{Author.take.id}")
+    end
+
+  end
 
 end

--- a/spec/support/admin.rb
+++ b/spec/support/admin.rb
@@ -2,6 +2,7 @@ def add_author_resource(options = {}, &block)
 
   ActiveAdmin.register Author do
     config.filters = true
+    decorate_with AuthorDecorator
 
     config.scoped_collection_actions_if = -> { true }
 

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -21,6 +21,7 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 
 generate :'active_admin:install --skip-users'
 generate :'formtastic:install'
+generate :'decorator Author'
 
 # Install active_admin_date_time_datetimepicker assets
 inject_into_file "app/assets/stylesheets/active_admin.scss",


### PR DESCRIPTION
There is an issue with batch_action_collection and decorators.
Method batch_action_collection usually returns AR relation but when ActiveAdmin decorators are used it returns an array of decorators instead, which has no 'where' method.
It crashes batch actions for models with decorators.

Removing :decorators from batch_action_collection solves the problem.