### PR TITLE
Update typo in mass update confirm box HTML

### DIFF
--- a/vendor/assets/javascripts/lib/dialog_mass_fields_update.js
+++ b/vendor/assets/javascripts/lib/dialog_mass_fields_update.js
@@ -1,5 +1,5 @@
 ActiveAdmin.dialogMassFieldsUpdate = function(message, inputs, callback){
-  let html = `<form id="dialog_confirm" title="${message}"><div stype="padding-right:4px;padding-left:1px;margin-right:2px"><ul>`;
+  let html = `<form id="dialog_confirm" title="${message}"><div style="padding-right:4px;padding-left:1px;margin-right:2px"><ul>`;
   for (let name in inputs) {
     var elem, opts, wrapper;
     let type = inputs[name];


### PR DESCRIPTION
Noticed a typo in the HTML for the mass update confirm box that resulted in styling not being applied to part of the dialog box.